### PR TITLE
refactor: centralize theme and remove gradients

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,6 +1,7 @@
 import type { AppProps } from 'next/app';
 import { AuthProvider } from '../context/AuthContext';
 import Head from 'next/head';
+import '../styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -12,7 +13,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-        <meta name="theme-color" content="#667eea" />
+        <meta name="theme-color" content="#1a73e8" />
         <meta name="apple-mobile-web-app-title" content="NexOffice" />
         {/* Favicon */}
         <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏢</text></svg>" />
@@ -23,109 +24,6 @@ export default function App({ Component, pageProps }: AppProps) {
       <AuthProvider>
         <Component {...pageProps} />
       </AuthProvider>
-      
-      <style jsx global>{`
-        * {
-          box-sizing: border-box;
-        }
-        
-        html, body {
-          margin: 0;
-          padding: 0;
-          height: 100%;
-          overflow-x: hidden;
-        }
-        
-        #__next {
-          height: 100%;
-        }
-        
-        /* Smooth animations */
-        @keyframes slideInUp {
-          from {
-            opacity: 0;
-            transform: translateY(20px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-        
-        @keyframes fadeIn {
-          from { opacity: 0; }
-          to { opacity: 1; }
-        }
-        
-        @keyframes spin {
-          from { transform: rotate(0deg); }
-          to { transform: rotate(360deg); }
-        }
-        
-        /* Mobile optimizations */
-        @media (max-width: 768px) {
-          /* Prevent zoom on input focus */
-          input, textarea, select {
-            font-size: 16px !important;
-          }
-          
-          /* Hide scrollbars on mobile */
-          ::-webkit-scrollbar {
-            display: none;
-          }
-          
-          /* Smooth scrolling */
-          html {
-            scroll-behavior: smooth;
-            -webkit-overflow-scrolling: touch;
-          }
-        }
-        
-        /* Custom scrollbar for desktop */
-        @media (min-width: 769px) {
-          ::-webkit-scrollbar {
-            width: 8px;
-          }
-          
-          ::-webkit-scrollbar-track {
-            background: #1f1f1f;
-          }
-          
-          ::-webkit-scrollbar-thumb {
-            background: #5f6368;
-            border-radius: 4px;
-          }
-          
-          ::-webkit-scrollbar-thumb:hover {
-            background: #8e8e8e;
-          }
-        }
-        
-        /* Focus styles */
-        button:focus,
-        input:focus,
-        textarea:focus {
-          outline: 2px solid #1a73e8;
-          outline-offset: 2px;
-        }
-        
-        /* Button hover effects */
-        button:not(:disabled):hover {
-          transform: translateY(-1px);
-        }
-        
-        button:not(:disabled):active {
-          transform: translateY(0);
-        }
-        
-        /* Disable text selection on UI elements */
-        button, .no-select {
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          user-select: none;
-        }
-      `}</style>
     </>
   );
-} 
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -26,14 +26,14 @@ export default function LandingPage() {
     return (
       <div style={{
         minHeight: '100vh',
-        background: 'linear-gradient(135deg, #1e293b 0%, #334155 100%)',
+        backgroundColor: 'var(--color-background)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: '"Inter", sans-serif'
       }}>
         <div style={{
-          color: 'white',
+          color: 'var(--color-text)',
           textAlign: 'center',
           fontSize: '18px'
         }}>
@@ -55,8 +55,8 @@ export default function LandingPage() {
 
       <div style={{
         fontFamily: '"Inter", sans-serif',
-        backgroundColor: '#0f172a',
-        color: 'white',
+        backgroundColor: 'var(--color-background)',
+        color: 'var(--color-text)',
         overflow: 'hidden'
       }}>
         {/* Fixed Navigation */}
@@ -71,9 +71,8 @@ export default function LandingPage() {
             right: 0,
             zIndex: 50,
             padding: '20px 40px',
-            background: 'rgba(15, 23, 42, 0.95)',
-            backdropFilter: 'blur(20px)',
-            borderBottom: '1px solid rgba(148, 163, 184, 0.1)',
+            backgroundColor: 'var(--color-background)',
+            borderBottom: '1px solid var(--color-primary)',
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center'
@@ -96,10 +95,7 @@ export default function LandingPage() {
             <span style={{
               fontSize: '24px',
               fontWeight: '800',
-              background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
-              backgroundClip: 'text',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent'
+              color: 'var(--color-primary)'
             }}>
               NexOffice
             </span>
@@ -112,27 +108,27 @@ export default function LandingPage() {
             alignItems: 'center'
           }}>
             <Link href="#features" style={{
-              color: '#94a3b8',
+              color: 'var(--color-text)',
               textDecoration: 'none',
               fontSize: '16px',
               fontWeight: '500',
               transition: 'color 0.3s ease'
             }}
-            onMouseOver={(e) => e.currentTarget.style.color = '#f1f5f9'}
-            onMouseOut={(e) => e.currentTarget.style.color = '#94a3b8'}
+            onMouseOver={(e) => e.currentTarget.style.color = 'var(--color-primary)'}
+            onMouseOut={(e) => e.currentTarget.style.color = 'var(--color-text)'}
             >
               Features
             </Link>
 
             <Link href="#about" style={{
-              color: '#94a3b8',
+              color: 'var(--color-text)',
               textDecoration: 'none',
               fontSize: '16px',
               fontWeight: '500',
               transition: 'color 0.3s ease'
             }}
-            onMouseOver={(e) => e.currentTarget.style.color = '#f1f5f9'}
-            onMouseOut={(e) => e.currentTarget.style.color = '#94a3b8'}
+            onMouseOver={(e) => e.currentTarget.style.color = 'var(--color-primary)'}
+            onMouseOut={(e) => e.currentTarget.style.color = 'var(--color-text)'}
             >
               About
             </Link>
@@ -172,7 +168,7 @@ export default function LandingPage() {
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
               <Link href="/signup" style={{
                 padding: '12px 24px',
-                background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                backgroundColor: 'var(--color-primary)',
                 color: 'white',
                 textDecoration: 'none',
                 borderRadius: '8px',
@@ -203,7 +199,7 @@ export default function LandingPage() {
           alignItems: 'center',
           justifyContent: 'center',
           position: 'relative',
-          background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #334155 100%)',
+          backgroundColor: 'var(--color-background)',
           overflow: 'hidden'
         }}>
           {/* Three.js Virtual Office Background */}
@@ -280,7 +276,7 @@ export default function LandingPage() {
                 fontWeight: '900',
                 margin: '0 0 24px 0',
                 lineHeight: '1.1',
-                background: 'linear-gradient(135deg, #f1f5f9 0%, #cbd5e1 100%)',
+                backgroundColor: 'var(--color-background)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent'
@@ -289,7 +285,7 @@ export default function LandingPage() {
               Transform Your
               <br />
               <span style={{
-                background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                backgroundColor: 'var(--color-primary)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent'
@@ -305,7 +301,7 @@ export default function LandingPage() {
               style={{
                 fontSize: '24px',
                 lineHeight: '1.5',
-                color: '#94a3b8',
+                color: 'var(--color-text)',
                 maxWidth: '600px',
                 margin: '0 auto 48px auto'
               }}
@@ -329,7 +325,7 @@ export default function LandingPage() {
               <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                 <Link href="/signup" style={{
                   padding: '20px 40px',
-                  background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                  backgroundColor: 'var(--color-primary)',
                   color: 'white',
                   textDecoration: 'none',
                   borderRadius: '12px',
@@ -425,7 +421,7 @@ export default function LandingPage() {
         {/* Features Section */}
         <section id="features" style={{
           padding: '120px 40px',
-          backgroundColor: '#1e293b',
+          backgroundColor: 'var(--color-background)',
           position: 'relative'
         }}>
           <div style={{
@@ -443,7 +439,7 @@ export default function LandingPage() {
                 fontSize: '48px',
                 fontWeight: '800',
                 margin: '0 0 24px 0',
-                background: 'linear-gradient(135deg, #f1f5f9 0%, #cbd5e1 100%)',
+                backgroundColor: 'var(--color-background)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent'
@@ -452,7 +448,7 @@ export default function LandingPage() {
               </h2>
               <p style={{
                 fontSize: '20px',
-                color: '#94a3b8',
+                color: 'var(--color-text)',
                 maxWidth: '600px',
                 margin: '0 auto'
               }}>
@@ -536,7 +532,7 @@ export default function LandingPage() {
                   </h3>
                   <p style={{
                     fontSize: '16px',
-                    color: '#94a3b8',
+                    color: 'var(--color-text)',
                     lineHeight: '1.6',
                     margin: 0
                   }}>
@@ -553,7 +549,7 @@ export default function LandingPage() {
         {/* About Section */}
         <section id="about" style={{
           padding: '120px 40px',
-          backgroundColor: '#1e293b'
+          backgroundColor: 'var(--color-background)'
         }}>
           <div style={{
             maxWidth: '1200px',
@@ -573,7 +569,7 @@ export default function LandingPage() {
                 fontSize: '48px',
                 fontWeight: '800',
                 margin: '0 0 24px 0',
-                background: 'linear-gradient(135deg, #f1f5f9 0%, #cbd5e1 100%)',
+                backgroundColor: 'var(--color-background)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent'
@@ -582,7 +578,7 @@ export default function LandingPage() {
               </h2>
               <p style={{
                 fontSize: '18px',
-                color: '#94a3b8',
+                color: 'var(--color-text)',
                 lineHeight: '1.7',
                 marginBottom: '32px'
               }}>
@@ -592,7 +588,7 @@ export default function LandingPage() {
               </p>
               <p style={{
                 fontSize: '18px',
-                color: '#94a3b8',
+                color: 'var(--color-text)',
                 lineHeight: '1.7',
                 marginBottom: '40px'
               }}>
@@ -602,7 +598,7 @@ export default function LandingPage() {
               <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                 <Link href="/signup" style={{
                   padding: '16px 32px',
-                  background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                  backgroundColor: 'var(--color-primary)',
                   color: 'white',
                   textDecoration: 'none',
                   borderRadius: '8px',
@@ -675,7 +671,7 @@ export default function LandingPage() {
         {/* Footer */}
         <footer style={{
           padding: '60px 40px 40px',
-          backgroundColor: '#0f172a',
+          backgroundColor: 'var(--color-background)',
           borderTop: '1px solid rgba(148, 163, 184, 0.1)'
         }}>
           <div style={{
@@ -694,7 +690,7 @@ export default function LandingPage() {
               <span style={{
                 fontSize: '24px',
                 fontWeight: '800',
-                background: 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                backgroundColor: 'var(--color-primary)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
                 WebkitTextFillColor: 'transparent'
@@ -719,13 +715,13 @@ export default function LandingPage() {
             }}>
               {['Privacy Policy', 'Terms of Service', 'Contact', 'Support'].map((link, index) => (
                 <a key={index} href="#" style={{
-                  color: '#94a3b8',
+                  color: 'var(--color-text)',
                   textDecoration: 'none',
                   fontSize: '14px',
                   transition: 'color 0.3s ease'
                 }}
                 onMouseOver={(e) => e.currentTarget.style.color = '#f1f5f9'}
-                onMouseOut={(e) => e.currentTarget.style.color = '#94a3b8'}
+                onMouseOut={(e) => e.currentTarget.style.color = 'var(--color-text)'}
                 >
                   {link}
                 </a>

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -94,14 +94,14 @@ export default function Login() {
     return (
       <div style={{
         minHeight: '100vh',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        backgroundColor: 'var(--color-background)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: '"Inter", sans-serif'
       }}>
         <div style={{
-          color: 'white',
+          color: 'var(--color-text)',
           textAlign: 'center',
           fontSize: '18px'
         }}>
@@ -123,7 +123,7 @@ export default function Login() {
 
       <div style={{
         minHeight: '100vh',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        backgroundColor: 'var(--color-background)',
         fontFamily: '"Inter", sans-serif',
         display: 'flex',
         alignItems: 'center',
@@ -163,7 +163,7 @@ export default function Login() {
               width: '80px',
               height: '80px',
               margin: '0 auto 24px',
-              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+              backgroundColor: 'var(--color-primary)',
               borderRadius: '20px',
               display: 'flex',
               alignItems: 'center',
@@ -177,19 +177,15 @@ export default function Login() {
             <h1 style={{
               fontSize: '32px',
               fontWeight: '800',
-              color: '#0F172A',
-              margin: '0 0 8px 0',
-              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-              backgroundClip: 'text',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent'
+              color: 'var(--color-primary)',
+              margin: '0 0 8px 0'
             }}>
               Welcome Back
             </h1>
 
             <p style={{
               fontSize: '16px',
-              color: '#64748B',
+              color: 'var(--color-text)',
               margin: 0
             }}>
               Sign in to your NexOffice workspace
@@ -203,9 +199,9 @@ export default function Login() {
             style={{
               width: '100%',
               padding: '16px 24px',
-              backgroundColor: isGoogleLoading ? '#94A3B8' : 'white',
-              color: isGoogleLoading ? 'white' : '#333',
-              border: '2px solid #E2E8F0',
+              backgroundColor: isGoogleLoading ? 'var(--color-text)' : 'var(--color-background)',
+              color: isGoogleLoading ? 'var(--color-background)' : 'var(--color-text)',
+              border: '2px solid var(--color-background)',
               borderRadius: '12px',
               fontSize: '16px',
               fontWeight: '600',
@@ -218,8 +214,8 @@ export default function Login() {
               marginBottom: '24px',
               opacity: isGoogleLoading ? 0.8 : 1
             }}
-            onMouseOver={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = '#667eea')}
-            onMouseOut={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = '#E2E8F0')}
+            onMouseOver={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = 'var(--color-primary)')}
+            onMouseOut={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = 'var(--color-background)')}
           >
             {isGoogleLoading ? (
               <>
@@ -227,7 +223,7 @@ export default function Login() {
                   width: '20px',
                   height: '20px',
                   border: '2px solid rgba(255,255,255,0.3)',
-                  borderTop: '2px solid white',
+                  borderTop: '2px solid var(--color-background)',
                   borderRadius: '50%',
                   animation: 'spin 1s linear infinite'
                 }} />
@@ -251,13 +247,13 @@ export default function Login() {
             display: 'flex',
             alignItems: 'center',
             margin: '32px 0',
-            color: '#94A3B8',
+            color: 'var(--color-text)',
             fontSize: '14px'
           }}>
             <div style={{
               flex: 1,
               height: '1px',
-              backgroundColor: '#E2E8F0'
+              backgroundColor: 'var(--color-background)'
             }} />
             <span style={{
               padding: '0 16px',
@@ -268,7 +264,7 @@ export default function Login() {
             <div style={{
               flex: 1,
               height: '1px',
-              backgroundColor: '#E2E8F0'
+              backgroundColor: 'var(--color-background)'
             }} />
           </div>
 
@@ -280,7 +276,7 @@ export default function Login() {
                 fontSize: '14px',
                 fontWeight: '600',
                 marginBottom: '8px',
-                color: '#374151'
+                color: 'var(--color-text)'
               }}>
                 Email Address
               </label>
@@ -293,14 +289,14 @@ export default function Login() {
                 style={{
                   width: '100%',
                   padding: '12px 16px',
-                  border: '2px solid #E2E8F0',
+                  border: '2px solid var(--color-background)',
                   borderRadius: '8px',
                   fontSize: '16px',
                   transition: 'border-color 0.3s ease',
-                  backgroundColor: 'white'
+                  backgroundColor: 'var(--color-background)'
                 }}
-                onFocus={(e) => e.currentTarget.style.borderColor = '#667eea'}
-                onBlur={(e) => e.currentTarget.style.borderColor = '#E2E8F0'}
+                onFocus={(e) => e.currentTarget.style.borderColor = 'var(--color-primary)'}
+                onBlur={(e) => e.currentTarget.style.borderColor = 'var(--color-background)'}
               />
             </div>
 
@@ -314,7 +310,7 @@ export default function Login() {
                 <label style={{
                   fontSize: '14px',
                   fontWeight: '600',
-                  color: '#374151'
+                  color: 'var(--color-text)'
                 }}>
                   Password
                 </label>
@@ -331,7 +327,7 @@ export default function Login() {
                   style={{
                     background: 'none',
                     border: 'none',
-                    color: '#667eea',
+                    color: 'var(--color-primary)',
                     fontSize: '13px',
                     fontWeight: '500',
                     cursor: 'pointer',
@@ -353,14 +349,14 @@ export default function Login() {
                 style={{
                   width: '100%',
                   padding: '12px 16px',
-                  border: '2px solid #E2E8F0',
+                  border: '2px solid var(--color-background)',
                   borderRadius: '8px',
                   fontSize: '16px',
                   transition: 'border-color 0.3s ease',
-                  backgroundColor: 'white'
+                  backgroundColor: 'var(--color-background)'
                 }}
-                onFocus={(e) => e.currentTarget.style.borderColor = '#667eea'}
-                onBlur={(e) => e.currentTarget.style.borderColor = '#E2E8F0'}
+                onFocus={(e) => e.currentTarget.style.borderColor = 'var(--color-primary)'}
+                onBlur={(e) => e.currentTarget.style.borderColor = 'var(--color-background)'}
               />
             </div>
 
@@ -370,8 +366,8 @@ export default function Login() {
               style={{
                 width: '100%',
                 padding: '16px 24px',
-                backgroundColor: isLoading || !email || !password ? '#94A3B8' : '#667eea',
-                color: 'white',
+                backgroundColor: isLoading || !email || !password ? 'var(--color-text)' : 'var(--color-primary)',
+                color: 'var(--color-background)',
                 border: 'none',
                 borderRadius: '12px',
                 fontSize: '16px',
@@ -391,7 +387,7 @@ export default function Login() {
                     width: '20px',
                     height: '20px',
                     border: '2px solid rgba(255,255,255,0.3)',
-                    borderTop: '2px solid white',
+                    borderTop: '2px solid var(--color-background)',
                     borderRadius: '50%',
                     animation: 'spin 1s linear infinite'
                   }} />
@@ -407,10 +403,10 @@ export default function Login() {
           {error && (
             <div style={{
               padding: '16px',
-              backgroundColor: '#FEF2F2',
-              border: '1px solid #FECACA',
+              backgroundColor: 'var(--color-background)',
+              border: '1px solid var(--color-primary)',
               borderRadius: '8px',
-              color: '#DC2626',
+              color: 'var(--color-primary)',
               fontSize: '14px',
               marginBottom: '24px',
               display: 'flex',
@@ -426,12 +422,12 @@ export default function Login() {
           <div style={{
             textAlign: 'center',
             fontSize: '14px',
-            color: '#64748B'
+            color: 'var(--color-text)'
           }}>
             <p style={{ margin: '0 0 16px 0' }}>
               Don't have an account?{' '}
               <Link href="/signup" style={{
-                color: '#667eea',
+                color: 'var(--color-primary)',
                 textDecoration: 'none',
                 fontWeight: '600'
               }}>
@@ -440,7 +436,7 @@ export default function Login() {
             </p>
             
             <Link href="/" style={{
-              color: '#64748B',
+              color: 'var(--color-text)',
               textDecoration: 'none',
               fontSize: '13px'
             }}>

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -104,14 +104,14 @@ export default function Signup() {
     return (
       <div style={{
         minHeight: '100vh',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        backgroundColor: 'var(--color-background)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         fontFamily: '"Inter", sans-serif'
       }}>
         <div style={{
-          color: 'white',
+          color: 'var(--color-text)',
           textAlign: 'center',
           fontSize: '18px'
         }}>
@@ -133,7 +133,7 @@ export default function Signup() {
 
       <div style={{
         minHeight: '100vh',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        backgroundColor: 'var(--color-background)',
         fontFamily: '"Inter", sans-serif',
         display: 'flex',
         alignItems: 'center',
@@ -169,41 +169,37 @@ export default function Signup() {
             textAlign: 'center',
             marginBottom: '40px'
           }}>
-            <div style={{
-              width: '80px',
-              height: '80px',
-              margin: '0 auto 24px',
-              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-              borderRadius: '20px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '32px',
-              boxShadow: '0 10px 25px -5px rgba(102, 126, 234, 0.4)'
-            }}>
-              🏢
-            </div>
+          <div style={{
+            width: '80px',
+            height: '80px',
+            margin: '0 auto 24px',
+            backgroundColor: 'var(--color-primary)',
+            borderRadius: '20px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: '32px',
+            boxShadow: '0 10px 25px -5px rgba(102, 126, 234, 0.4)'
+          }}>
+            🏢
+          </div>
 
-            <h1 style={{
-              fontSize: '32px',
-              fontWeight: '800',
-              color: '#0F172A',
-              margin: '0 0 8px 0',
-              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-              backgroundClip: 'text',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent'
-            }}>
-              Join NexOffice
-            </h1>
+          <h1 style={{
+            fontSize: '32px',
+            fontWeight: '800',
+            color: 'var(--color-primary)',
+            margin: '0 0 8px 0'
+          }}>
+            Join NexOffice
+          </h1>
 
-            <p style={{
-              fontSize: '16px',
-              color: '#64748B',
-              margin: 0
-            }}>
-              Create your account and start collaborating
-            </p>
+          <p style={{
+            fontSize: '16px',
+            color: 'var(--color-text)',
+            margin: 0
+          }}>
+            Create your account and start collaborating
+          </p>
           </div>
 
           {/* Google Sign Up Button */}
@@ -213,9 +209,9 @@ export default function Signup() {
             style={{
               width: '100%',
               padding: '16px 24px',
-              backgroundColor: isGoogleLoading ? '#94A3B8' : 'white',
-              color: isGoogleLoading ? 'white' : '#333',
-              border: '2px solid #E2E8F0',
+              backgroundColor: isGoogleLoading ? 'var(--color-text)' : 'var(--color-background)',
+              color: isGoogleLoading ? 'var(--color-background)' : 'var(--color-text)',
+              border: '2px solid var(--color-background)',
               borderRadius: '12px',
               fontSize: '16px',
               fontWeight: '600',
@@ -228,8 +224,8 @@ export default function Signup() {
               marginBottom: '24px',
               opacity: isGoogleLoading ? 0.8 : 1
             }}
-            onMouseOver={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = '#667eea')}
-            onMouseOut={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = '#E2E8F0')}
+            onMouseOver={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = 'var(--color-primary)')}
+            onMouseOut={(e) => !isGoogleLoading && (e.currentTarget.style.borderColor = 'var(--color-background)')}
           >
             {isGoogleLoading ? (
               <>
@@ -237,7 +233,7 @@ export default function Signup() {
                   width: '20px',
                   height: '20px',
                   border: '2px solid rgba(255,255,255,0.3)',
-                  borderTop: '2px solid white',
+                  borderTop: '2px solid var(--color-background)',
                   borderRadius: '50%',
                   animation: 'spin 1s linear infinite'
                 }} />
@@ -261,13 +257,13 @@ export default function Signup() {
             display: 'flex',
             alignItems: 'center',
             margin: '32px 0',
-            color: '#94A3B8',
+            color: 'var(--color-text)',
             fontSize: '14px'
           }}>
             <div style={{
               flex: 1,
               height: '1px',
-              backgroundColor: '#E2E8F0'
+              backgroundColor: 'var(--color-background)'
             }} />
             <span style={{
               padding: '0 16px',
@@ -278,7 +274,7 @@ export default function Signup() {
             <div style={{
               flex: 1,
               height: '1px',
-              backgroundColor: '#E2E8F0'
+              backgroundColor: 'var(--color-background)'
             }} />
           </div>
 
@@ -290,7 +286,7 @@ export default function Signup() {
                 fontSize: '14px',
                 fontWeight: '600',
                 marginBottom: '8px',
-                color: '#374151'
+                color: 'var(--color-text)'
               }}>
                 Full Name
               </label>
@@ -303,14 +299,14 @@ export default function Signup() {
                 style={{
                   width: '100%',
                   padding: '12px 16px',
-                  border: '2px solid #E2E8F0',
+                  border: '2px solid var(--color-background)',
                   borderRadius: '8px',
                   fontSize: '16px',
                   transition: 'border-color 0.3s ease',
-                  backgroundColor: 'white'
+                  backgroundColor: 'var(--color-background)'
                 }}
-                onFocus={(e) => e.currentTarget.style.borderColor = '#667eea'}
-                onBlur={(e) => e.currentTarget.style.borderColor = '#E2E8F0'}
+                onFocus={(e) => e.currentTarget.style.borderColor = 'var(--color-primary)'}
+                onBlur={(e) => e.currentTarget.style.borderColor = 'var(--color-background)'}
               />
             </div>
 
@@ -320,7 +316,7 @@ export default function Signup() {
                 fontSize: '14px',
                 fontWeight: '600',
                 marginBottom: '8px',
-                color: '#374151'
+                color: 'var(--color-text)'
               }}>
                 Email Address
               </label>
@@ -333,14 +329,14 @@ export default function Signup() {
                 style={{
                   width: '100%',
                   padding: '12px 16px',
-                  border: '2px solid #E2E8F0',
+                  border: '2px solid var(--color-background)',
                   borderRadius: '8px',
                   fontSize: '16px',
                   transition: 'border-color 0.3s ease',
-                  backgroundColor: 'white'
+                  backgroundColor: 'var(--color-background)'
                 }}
-                onFocus={(e) => e.currentTarget.style.borderColor = '#667eea'}
-                onBlur={(e) => e.currentTarget.style.borderColor = '#E2E8F0'}
+                onFocus={(e) => e.currentTarget.style.borderColor = 'var(--color-primary)'}
+                onBlur={(e) => e.currentTarget.style.borderColor = 'var(--color-background)'}
               />
             </div>
 
@@ -350,7 +346,7 @@ export default function Signup() {
                 fontSize: '14px',
                 fontWeight: '600',
                 marginBottom: '8px',
-                color: '#374151'
+                color: 'var(--color-text)'
               }}>
                 Password
               </label>
@@ -363,14 +359,14 @@ export default function Signup() {
                 style={{
                   width: '100%',
                   padding: '12px 16px',
-                  border: '2px solid #E2E8F0',
+                  border: '2px solid var(--color-background)',
                   borderRadius: '8px',
                   fontSize: '16px',
                   transition: 'border-color 0.3s ease',
-                  backgroundColor: 'white'
+                  backgroundColor: 'var(--color-background)'
                 }}
-                onFocus={(e) => e.currentTarget.style.borderColor = '#667eea'}
-                onBlur={(e) => e.currentTarget.style.borderColor = '#E2E8F0'}
+                onFocus={(e) => e.currentTarget.style.borderColor = 'var(--color-primary)'}
+                onBlur={(e) => e.currentTarget.style.borderColor = 'var(--color-background)'}
               />
             </div>
 
@@ -380,7 +376,7 @@ export default function Signup() {
                 fontSize: '14px',
                 fontWeight: '600',
                 marginBottom: '8px',
-                color: '#374151'
+                color: 'var(--color-text)'
               }}>
                 Confirm Password
               </label>
@@ -393,14 +389,14 @@ export default function Signup() {
                 style={{
                   width: '100%',
                   padding: '12px 16px',
-                  border: '2px solid #E2E8F0',
+                  border: '2px solid var(--color-background)',
                   borderRadius: '8px',
                   fontSize: '16px',
                   transition: 'border-color 0.3s ease',
-                  backgroundColor: 'white'
+                  backgroundColor: 'var(--color-background)'
                 }}
-                onFocus={(e) => e.currentTarget.style.borderColor = '#667eea'}
-                onBlur={(e) => e.currentTarget.style.borderColor = '#E2E8F0'}
+                onFocus={(e) => e.currentTarget.style.borderColor = 'var(--color-primary)'}
+                onBlur={(e) => e.currentTarget.style.borderColor = 'var(--color-background)'}
               />
             </div>
 
@@ -410,8 +406,8 @@ export default function Signup() {
               style={{
                 width: '100%',
                 padding: '16px 24px',
-                backgroundColor: isLoading || !email || !password || !confirmPassword || !fullName ? '#94A3B8' : '#667eea',
-                color: 'white',
+                backgroundColor: isLoading || !email || !password || !confirmPassword || !fullName ? 'var(--color-text)' : 'var(--color-primary)',
+                color: 'var(--color-background)',
                 border: 'none',
                 borderRadius: '12px',
                 fontSize: '16px',
@@ -431,7 +427,7 @@ export default function Signup() {
                     width: '20px',
                     height: '20px',
                     border: '2px solid rgba(255,255,255,0.3)',
-                    borderTop: '2px solid white',
+                    borderTop: '2px solid var(--color-background)',
                     borderRadius: '50%',
                     animation: 'spin 1s linear infinite'
                   }} />
@@ -447,10 +443,10 @@ export default function Signup() {
           {error && (
             <div style={{
               padding: '16px',
-              backgroundColor: '#FEF2F2',
-              border: '1px solid #FECACA',
+              backgroundColor: 'var(--color-background)',
+              border: '1px solid var(--color-primary)',
               borderRadius: '8px',
-              color: '#DC2626',
+              color: 'var(--color-primary)',
               fontSize: '14px',
               marginBottom: '24px',
               display: 'flex',
@@ -466,12 +462,12 @@ export default function Signup() {
           <div style={{
             textAlign: 'center',
             fontSize: '14px',
-            color: '#64748B'
+            color: 'var(--color-text)'
           }}>
             <p style={{ margin: '0 0 16px 0' }}>
               Already have an account?{' '}
               <Link href="/login" style={{
-                color: '#667eea',
+                color: 'var(--color-primary)',
                 textDecoration: 'none',
                 fontWeight: '600'
               }}>
@@ -480,7 +476,7 @@ export default function Signup() {
             </p>
             
             <Link href="/" style={{
-              color: '#64748B',
+              color: 'var(--color-text)',
               textDecoration: 'none',
               fontSize: '13px'
             }}>
@@ -492,16 +488,16 @@ export default function Signup() {
           <div style={{
             marginTop: '24px',
             padding: '16px',
-            backgroundColor: '#F8FAFC',
+            backgroundColor: 'var(--color-background)',
             borderRadius: '8px',
             fontSize: '12px',
-            color: '#64748B',
+            color: 'var(--color-text)',
             textAlign: 'center'
           }}>
             By creating an account, you agree to our{' '}
-            <a href="#" style={{ color: '#667eea', textDecoration: 'none' }}>Terms of Service</a>
+            <a href="#" style={{ color: 'var(--color-primary)', textDecoration: 'none' }}>Terms of Service</a>
             {' '}and{' '}
-            <a href="#" style={{ color: '#667eea', textDecoration: 'none' }}>Privacy Policy</a>
+            <a href="#" style={{ color: 'var(--color-primary)', textDecoration: 'none' }}>Privacy Policy</a>
           </div>
         </div>
       </div>

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,100 @@
+:root {
+  --color-primary: #1a73e8;
+  --color-background: #ffffff;
+  --color-text: #202124;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow-x: hidden;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: 'Inter', sans-serif;
+}
+
+#__next {
+  height: 100%;
+}
+
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 768px) {
+  input, textarea, select {
+    font-size: 16px !important;
+  }
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  html {
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+@media (min-width: 769px) {
+  ::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: var(--color-background);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #5f6368;
+    border-radius: 4px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #8e8e8e;
+  }
+}
+
+button:focus,
+input:focus,
+textarea:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+button:not(:disabled):active {
+  transform: translateY(0);
+}
+
+button, .no-select {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}


### PR DESCRIPTION
## Summary
- centralize primary, background, and text colors in a new global stylesheet
- swap gradient-heavy navigation and landing elements for a solid two-color theme
- simplify login and signup pages to use the shared palette and remove gradients

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e37cff79883309d3c7de281bb6d99